### PR TITLE
Add continuous NPC spawning for endless mode

### DIFF
--- a/autoload/RhythmManager.gd
+++ b/autoload/RhythmManager.gd
@@ -11,16 +11,26 @@ var song_position_in_beats: float = 0
 var sec_per_beat: float = 60.0 / bpm
 var last_beat: int = 0
 var current_measure: int = 1
+var time_since_start: float = 0.0
 
 var playing: bool = false
 var current_song: AudioStream
+var use_internal_clock: bool = true  # Use internal clock when no audio is available
 
 func _ready() -> void:
 	pass
 
 func _process(delta: float) -> void:
 	if playing:
-		song_position = AudioManager.get_playback_position()
+		# Get position from audio if available, otherwise use internal clock
+		if current_song != null and not use_internal_clock:
+			song_position = AudioManager.get_playback_position()
+		else:
+			# Use internal clock based on delta time
+			time_since_start += delta
+			song_position = time_since_start
+		
+		# Calculate beats
 		song_position_in_beats = song_position / sec_per_beat
 		
 		if last_beat < int(song_position_in_beats):
@@ -31,13 +41,20 @@ func _process(delta: float) -> void:
 				current_measure = (last_beat / measures) + 1
 				measure_complete.emit(current_measure)
 
-func start_song(song: AudioStream, starting_bpm: float) -> void:
+func start_song(song: AudioStream = null, starting_bpm: float = 120.0) -> void:
 	current_song = song
 	bpm = starting_bpm
 	sec_per_beat = 60.0 / bpm
 	last_beat = 0
 	current_measure = 1
-	AudioManager.play_song(song)
+	time_since_start = 0.0
+	
+	if song != null:
+		AudioManager.play_song(song)
+		use_internal_clock = false
+	else:
+		use_internal_clock = true
+		
 	playing = true
 
 func stop_song() -> void:

--- a/scenes/level/NPCSpawner.tscn
+++ b/scenes/level/NPCSpawner.tscn
@@ -4,3 +4,8 @@
 
 [node name="NPCSpawner" type="Node2D"]
 script = ExtResource("1_biyui")
+continuous_spawning = true
+spawn_rate_min = 1.0
+spawn_rate_max = 3.0
+spawn_count_min = 1
+spawn_count_max = 2

--- a/scenes/level/level.gd
+++ b/scenes/level/level.gd
@@ -14,6 +14,7 @@ var score: int = 0
 var max_combo: int = 0
 var current_combo: int = 0
 var game_state: String = "ready"  # ready, playing, paused, completed
+var is_endless_mode: bool = false
 
 func _ready() -> void:
 	player = $Player
@@ -30,20 +31,35 @@ func _ready() -> void:
 	# Make this node findable by name for NPCs
 	name = "GameLevel"
 	
-	if level_data:
-		setup_level()
+	# Check for endless mode
+	if level_data == null:
+		is_endless_mode = true
+		print("Endless mode detected")
+	
+	setup_level()
 
 func setup_level() -> void:
-	# Set up NPC spawner with level data
-	npc_spawner.level_data = level_data
-	
-	# Initialize UI
-	ui_layer.initialize(level_data.level_name)
-	
 	# Reset score and combo
 	score = 0
 	max_combo = 0
 	current_combo = 0
+	
+	if is_endless_mode:
+		# Endless mode setup
+		npc_spawner.level_data = null
+		npc_spawner.continuous_spawning = true
+		
+		# Initialize UI with default name
+		ui_layer.initialize("Endless Mode")
+		print("Setting up endless mode")
+	else:
+		# Level data mode
+		npc_spawner.level_data = level_data
+		npc_spawner.continuous_spawning = false
+		
+		# Initialize UI with level name
+		ui_layer.initialize(level_data.level_name)
+	
 	ui_layer.update_score(score)
 	ui_layer.update_combo(current_combo)
 	
@@ -54,30 +70,113 @@ func start_level() -> void:
 		return
 		
 	game_state = "playing"
+	print("Starting level, endless mode:", is_endless_mode)
 	
 	if Engine.has_singleton("RhythmManager"):
 		var rhythm_manager = Engine.get_singleton("RhythmManager")
-		rhythm_manager.start_song(level_data.song_file, level_data.bpm)
+		
+		if is_endless_mode:
+			# Start with internal clock at 120 BPM
+			rhythm_manager.start_song(null, 120.0)
+			print("Started rhythm manager in endless mode")
+		elif level_data != null and level_data.song_file != null:
+			# Start with actual audio file and BPM
+			rhythm_manager.start_song(level_data.song_file, level_data.bpm)
 	
-	# Start background scrolling
-	# This will be handled by the background manager based on BPM
+	# If in endless mode, immediately start spawning NPCs
+	if is_endless_mode:
+		call_deferred("_force_spawn_npc")
+
+func _force_spawn_npc() -> void:
+	# This function sets up the spawning system in endless mode
+	if npc_spawner and is_endless_mode:
+		print("Starting continuous NPC spawning")
+		
+		# Just to be extra sure, set the flag for continuous spawning
+		npc_spawner.continuous_spawning = true
+		
+		# Create a timer to spawn NPCs regularly
+		var spawn_timer = Timer.new()
+		spawn_timer.name = "SpawnTimer"
+		add_child(spawn_timer)
+		spawn_timer.wait_time = 1.0  # Spawn a new NPC every second
+		spawn_timer.timeout.connect(_on_spawn_timer_timeout)
+		spawn_timer.start()
+		
+		# Also spawn one NPC immediately to have something right away
+		_on_spawn_timer_timeout()
+			
+		# Make sure RhythmManager is running for beat tracking
+		if Engine.has_singleton("RhythmManager"):
+			var rhythm_manager = Engine.get_singleton("RhythmManager")
+			rhythm_manager.playing = true
+
+# This gets called by the spawn timer to create a new NPC
+func _on_spawn_timer_timeout() -> void:
+	if not is_endless_mode or game_state != "playing":
+		return
+		
+	# Determine random NPC properties
+	var npc_types = ["oscillator", "percussion"]
+	var npc_type = npc_types[randi() % npc_types.size()]
+	
+	# Choose random horizontal position (with some safe margins)
+	var margin = 0.1
+	var x_position = randf_range(margin, 1.0 - margin)
+	
+	# Set a target beat based on current position
+	var target_beat = 4.0  # Default
+	if Engine.has_singleton("RhythmManager"):
+		var rhythm_manager = Engine.get_singleton("RhythmManager")
+		target_beat = rhythm_manager.song_position_in_beats + 2.0  # 2 beats ahead
+	
+	# Create spawn data
+	var spawn_data = {
+		"type": npc_type,
+		"position_x": x_position,
+		"beat": target_beat
+	}
+	
+	# Spawn the NPC
+	npc_spawner.spawn_npc(spawn_data)
+	
+	# Log occasionally (not every spawn)
+	if randf() < 0.1:  # 10% chance to log
+		print("Spawned NPC: ", npc_type, " at position ", x_position, " for beat ", target_beat)
 
 func pause_level() -> void:
 	if game_state != "playing":
 		return
 		
 	game_state = "paused"
-	# Handle pause logic
+	
+	# Pause the spawn timer if in endless mode
+	if is_endless_mode and has_node("SpawnTimer"):
+		var timer = get_node("SpawnTimer")
+		timer.paused = true
+	
+	# Additional pause logic here
 
 func resume_level() -> void:
 	if game_state != "paused":
 		return
 		
 	game_state = "playing"
-	# Handle resume logic
+	
+	# Resume the spawn timer if in endless mode
+	if is_endless_mode and has_node("SpawnTimer"):
+		var timer = get_node("SpawnTimer")
+		timer.paused = false
+	
+	# Additional resume logic here
 
 func complete_level() -> void:
 	game_state = "completed"
+	
+	# Stop spawn timer if in endless mode
+	if is_endless_mode and has_node("SpawnTimer"):
+		var timer = get_node("SpawnTimer")
+		timer.stop()
 	
 	if Engine.has_singleton("RhythmManager"):
 		var rhythm_manager = Engine.get_singleton("RhythmManager")
@@ -87,6 +186,11 @@ func complete_level() -> void:
 
 func fail_level() -> void:
 	game_state = "failed"
+	
+	# Stop spawn timer if in endless mode
+	if is_endless_mode and has_node("SpawnTimer"):
+		var timer = get_node("SpawnTimer")
+		timer.stop()
 	
 	if Engine.has_singleton("RhythmManager"):
 		var rhythm_manager = Engine.get_singleton("RhythmManager")
@@ -109,15 +213,25 @@ func _on_score_updated(points: int, accuracy: String) -> void:
 	ui_layer.show_accuracy(accuracy)
 
 func _process(delta: float) -> void:
-	if game_state == "playing" and Engine.has_singleton("RhythmManager"):
-		var rhythm_manager = Engine.get_singleton("RhythmManager")
-		# Check if song is finished
-		if rhythm_manager.playing and rhythm_manager.song_position >= level_data.level_duration:
-			complete_level()
-			
+	if game_state == "playing":
+		var rhythm_manager = null
+		if Engine.has_singleton("RhythmManager"):
+			rhythm_manager = Engine.get_singleton("RhythmManager")
+		
+		# In endless mode, display debugging info
+		if is_endless_mode and rhythm_manager and Engine.get_frames_drawn() % 120 == 0:
+			print("Beat: ", rhythm_manager.song_position_in_beats, 
+				  " NPCs: ", npc_spawner.active_npcs.size(),
+				  " Next spawn: ", npc_spawner.next_spawn_beat)
+		
+		# Check if song is finished, but only for predefined levels
+		if not is_endless_mode and rhythm_manager and level_data != null:
+			if rhythm_manager.playing and rhythm_manager.song_position >= level_data.level_duration:
+				complete_level()
+		
 	# Draw interaction zone line
 	queue_redraw()
-	
+
 func _draw() -> void:
 	# Draw a horizontal line to indicate the interaction zone
 	if player:

--- a/scenes/level/npc_spawner.gd
+++ b/scenes/level/npc_spawner.gd
@@ -5,11 +5,20 @@ signal npc_scored(points, accuracy)
 
 @export var level_data: LevelData
 @export var spawn_offset: float = -100.0  # Spawn above screen
+@export var continuous_spawning: bool = true  # Enable automatic NPC generation
+@export var spawn_rate_min: float = 1.0  # Minimum beats between spawns
+@export var spawn_rate_max: float = 3.0  # Maximum beats between spawns
+@export var spawn_count_min: int = 1  # Minimum NPCs to spawn at once
+@export var spawn_count_max: int = 2  # Maximum NPCs to spawn at once
 
 var npc_pools: Dictionary = {}
 var active_npcs: Array[NPCBase] = []
 var screen_width: float
 var current_time: float = 0.0
+var next_spawn_beat: float = 2.0  # First spawn at beat 2
+var npc_types: Array = ["oscillator", "percussion"]
+var last_beat: int = -1
+var debug_mode: bool = true  # Enable debug prints
 
 func _ready() -> void:
 	screen_width = get_viewport_rect().size.x
@@ -18,20 +27,43 @@ func _ready() -> void:
 	if Engine.has_singleton("RhythmManager"):
 		var rhythm_manager = Engine.get_singleton("RhythmManager")
 		rhythm_manager.beat.connect(_on_beat)
+		
+	# Print debug status
+	if debug_mode:
+		print("NPCSpawner initialized")
+		print("Continuous spawning: ", continuous_spawning)
+		print("NPC Types: ", npc_types)
 
 func _process(delta: float) -> void:
 	if Engine.has_singleton("RhythmManager"):
 		var rhythm_manager = Engine.get_singleton("RhythmManager")
 		current_time = rhythm_manager.song_position
+		
+		# If there's no music playing but continuous spawning is enabled, 
+		# generate NPCs at a steady rhythm even without music
+		if continuous_spawning and not rhythm_manager.playing:
+			rhythm_manager.start_song(null, 120.0)  # Start with internal clock
+			if debug_mode:
+				print("Starting rhythm with internal clock")
 	else:
 		current_time += delta
 		
-	check_spawn_npcs()
+	# Check for predefined level data NPC spawns
+	if level_data != null:
+		check_spawn_npcs()
+		
+	# Always process active NPCs
 	process_active_npcs()
+	
+	# Debug display
+	if debug_mode and Engine.has_singleton("RhythmManager"):
+		var rm = Engine.get_singleton("RhythmManager")
+		if continuous_spawning and (Engine.get_frames_drawn() % 120 == 0): # Show only every 120 frames
+			print("Beat: ", rm.song_position_in_beats, " Active NPCs: ", active_npcs.size())
 
 func initialize_object_pools() -> void:
-	# This will be filled with actual NPC types during development
-	var npc_types = {
+	# Create pools for each NPC type
+	var configs = {
 		"oscillator": {
 			"scene": preload("res://scenes/npcs/NPC_Oscillator.tscn"),
 			"count": 20
@@ -42,14 +74,22 @@ func initialize_object_pools() -> void:
 		}
 	}
 	
-	# Create pools for each NPC type
-	for type in npc_types:
+	# First make sure the keys in this dictionary match our npc_types array
+	if npc_types.size() != configs.keys().size():
+		npc_types = configs.keys()
+		print("Synchronized npc_types with config keys:", npc_types)
+	
+	for type in configs:
 		npc_pools[type] = []
-		for i in range(npc_types[type]["count"]):
-			var npc = npc_types[type]["scene"].instantiate()
+		for i in range(configs[type]["count"]):
+			var npc = configs[type]["scene"].instantiate()
 			npc.deactivate()
 			add_child(npc)
 			npc_pools[type].append(npc)
+			
+	if debug_mode:
+		print("Created NPC pools: ", npc_pools.keys(), " with ", npc_pools["oscillator"].size(), " oscillators and ", npc_pools["percussion"].size(), " percussion")
+		print("Continuous spawning setting:", continuous_spawning)
 
 func check_spawn_npcs() -> void:
 	if level_data == null:
@@ -84,6 +124,8 @@ func spawn_npc(spawn_data: Dictionary) -> void:
 		for npc in npc_pools[npc_type]:
 			if not npc.is_active:
 				activate_npc(npc, spawn_data["beat"], Vector2(x_position, spawn_offset))
+				if debug_mode:
+					print("Spawned NPC: ", npc_type, " at position ", x_position)
 				return
 	
 	print("Warning: No available NPC in pool for type: " + npc_type)
@@ -112,5 +154,48 @@ func process_active_npcs() -> void:
 		active_npcs.erase(npc)
 
 func _on_beat(beat_count: int) -> void:
-	# We can use this for visual timing cues if needed
-	pass
+	# Skip if it's the same beat (prevent duplicate processing)
+	if beat_count == last_beat:
+		return
+		
+	last_beat = beat_count
+	
+	# Check if it's time to spawn NPCs based on beat
+	if continuous_spawning and beat_count >= next_spawn_beat:
+		# Spawn 1-2 NPCs
+		var spawn_count = randi_range(spawn_count_min, spawn_count_max)
+		
+		if debug_mode:
+			print("Beat ", beat_count, ": Spawning ", spawn_count, " NPCs")
+		
+		for i in range(spawn_count):
+			spawn_random_npc(beat_count)
+		
+		# Schedule next spawn
+		next_spawn_beat = beat_count + randf_range(spawn_rate_min, spawn_rate_max)
+		
+func spawn_random_npc(current_beat: float) -> void:
+	# Ensure we have NPC types defined
+	if npc_types.size() == 0:
+		npc_types = ["oscillator", "percussion"]
+		if debug_mode:
+			print("Reset NPC types to default")
+	
+	# Choose a random NPC type
+	var npc_type = npc_types[randi() % npc_types.size()]
+	
+	# Generate random horizontal position
+	var x_position = randf_range(0.1, 0.9) * screen_width
+	
+	# Define beat timing (slightly ahead to account for travel time)
+	var target_beat = current_beat + 2.0  # Target beat is 2 beats ahead
+	
+	# Create spawn data
+	var spawn_data = {
+		"type": npc_type,
+		"position_x": x_position / screen_width,
+		"beat": target_beat
+	}
+	
+	# Spawn the NPC
+	spawn_npc(spawn_data)

--- a/scenes/npcs/npc_base.gd
+++ b/scenes/npcs/npc_base.gd
@@ -10,7 +10,7 @@ signal interaction_triggered(points, accuracy)
 @export var interaction_radius: float = 80.0  # Radius for proximity detection
 @export var interaction_zone_y: float = 960.0  # Y position of the interaction zone
 
-var speed: float = 200.0
+var speed: float = 300.0  # Increased speed for better gameplay
 var is_active: bool = false
 var was_interacted: bool = false
 var player_ref = null  # Removed type annotation

--- a/scenes/ui/MainMenu.tscn
+++ b/scenes/ui/MainMenu.tscn
@@ -103,6 +103,11 @@ layout_mode = 2
 text = "Level Select"
 horizontal_alignment = 1
 
+[node name="EndlessModeButton" type="Button" parent="LevelSelectContainer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "Endless Mode"
+
 [node name="Level1Button" type="Button" parent="LevelSelectContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3

--- a/scenes/ui/main_menu.gd
+++ b/scenes/ui/main_menu.gd
@@ -5,6 +5,7 @@ extends Control
 @onready var settings_button: Button = $VBoxContainer/SettingsButton
 @onready var quit_button: Button = $VBoxContainer/QuitButton
 @onready var level_select_container: Control = $LevelSelectContainer
+@onready var endless_mode_button: Button = $LevelSelectContainer/VBoxContainer/EndlessModeButton
 @onready var level1_button: Button = $LevelSelectContainer/VBoxContainer/Level1Button
 @onready var back_button: Button = $LevelSelectContainer/VBoxContainer/BackButton
 
@@ -20,6 +21,9 @@ func _ready() -> void:
 		
 	if level_select_container:
 		level_select_container.visible = false
+	
+	if endless_mode_button:
+		endless_mode_button.pressed.connect(func(): start_endless_mode())
 		
 	if level1_button:
 		level1_button.pressed.connect(func(): start_level("res://resources/levels/level_1.tres"))
@@ -49,3 +53,18 @@ func start_level(level_path: String) -> void:
 	get_tree().root.add_child(game_scene)
 	get_tree().current_scene.queue_free()
 	get_tree().current_scene = game_scene
+	
+	# Start the level automatically
+	game_scene.call_deferred("start_level")
+	
+func start_endless_mode() -> void:
+	var game_scene = load("res://scenes/level/Level.tscn").instantiate()
+	game_scene.level_data = null  # No level data triggers endless mode
+	
+	# Replace the current scene with the game scene
+	get_tree().root.add_child(game_scene)
+	get_tree().current_scene.queue_free()
+	get_tree().current_scene = game_scene
+	
+	# Start the level automatically
+	game_scene.call_deferred("start_level")


### PR DESCRIPTION
- Implement timer-based NPC spawning to create continuous stream of NPCs
- Add proper spawning, pausing, and stopping of NPCs in endless mode
- Increase NPC movement speed for better gameplay
- Fix issue with only 4 NPCs appearing at once
- Add proper beat tracking in endless mode
- Update UI to properly show endless mode option
- Improve randomization of NPC positions and types

🤖 Generated with [Claude Code](https://claude.ai/code)